### PR TITLE
snip-cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           # (required) Comma-separated list of binary names (non-extension portion of filename) to build and upload.
           # Note that glob pattern is not supported yet.
-          bin: snipr
+          bin: snip
           # (optional) Target triple, default is host triple.
           target: ${{ matrix.target }}
           # (required) GitHub token for uploading assets to GitHub Releases.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,8 +583,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
-name = "snipr"
-version = "0.1.0"
+name = "snip-cli"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap 4.4.11",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,25 @@
 [package]
-name = "snipr"
-version = "0.1.0"
+name = "snip-cli"
+version = "0.1.1"
 edition = "2021"
 authors = ["Uriah G. <codeitlikemiley@gmail.com>"]
-description = "A CLI tool (snipr) for managing Neovim and  VSCode snippets"
+description = "A CLI tool (snip-cli) for managing Neovim and  VSCode snippets"
 readme = "README.md"
 license = "MIT"
 keywords = ["neovim", "snippets", "rust", "cli", "vscode"]
 categories = ["command-line-utilities"]
+
+# use in Github workflow `release`
+[[bin]]
+name = "snip"
+path = "src/main.rs"
+
+# Used when Bunding for OSX
+[[bin]]
+name = "snip-cli"
+path = "src/main.rs"
+
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -22,15 +34,15 @@ dirs-next = "2.0.0"
 dotenv = { version = "0.15.0", features = ["clap"] }
 
 [package.metadata.bundle]
-name = "snipr" # The name of your application
-identifier = "com.codeitlikemiley.snipr" # The bundle identifier of your application
+name = "snip" # The name of your application
+identifier = "com.codeitlikemiley.snip" # The bundle identifier of your application
 copyright = "Copyright (c) codeitlikemiley 2023. All rights reserved."
 category = "Developer Tool"
 short_description = "A CLI tool for managing Neovim and VSCode snippets"
 long_description = "A CLI tool for managing Neovim and VSCode snippets"
-version = "0.1.0" # Version of your application
+version = "0.1.1" # Version of your application
 osx_url_schemes = [
-  "com.codeitlikemiley.snipr",
+  "com.codeitlikemiley.snip",
 ] # URL schemes your application supports
 script = "scripts/postinstall" # Path to your postinstall script
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# A CLI (snipr) Tool for Managing Neovim and VSCode Snippets
+# A CLI (snip-cli) Tool for Managing Neovim and VSCode Snippets
 
-[![Rust Build and Test](https://github.com/codeitlikemiley/snipr/actions/workflows/test.yml/badge.svg)](https://github.com/codeitlikemiley/snipr/actions/workflows/test.yml)
+[![Rust Build and Test](https://github.com/codeitlikemiley/snip-cli/actions/workflows/test.yml/badge.svg)](https://github.com/codeitlikemiley/snip-cli/actions/workflows/test.yml)
 
-[![release](https://github.com/codeitlikemiley/snipr/actions/workflows/release.yml/badge.svg)](https://github.com/codeitlikemiley/snipr/actions/workflows/release.yml)
+[![release](https://github.com/codeitlikemiley/snip-cli/actions/workflows/release.yml/badge.svg)](https://github.com/codeitlikemiley/snip-cli/actions/workflows/release.yml)
 
 Note: This is an additional tools to be used with my [Neovide Neovim](https://github.com/codeitlikemiley/nvim) rust setup.
 
@@ -10,52 +10,20 @@ Note: This is an additional tools to be used with my [Neovide Neovim](https://gi
 
 ## Installation
 
-1. You can Download and Install [snipr](https://github.com/codeitlikemiley/snipr/releases) on Releases Page
+1. You can Download and Install [snip-cli](https://github.com/codeitlikemiley/snip-cli/releases) on Releases Page
 Note: on MacOS you might need to go to System Preferences > Security & Privacy > General and click Open Anyway to install it
 
 Note: on Windows you might need to Add the command to ENV PATH
 
-or Install it using Cargo
+2. Install it using Cargo
 
 ```sh
-cargo install snipr
-```
-
-
-
-2. Build it from source
-### Clone
-```sh
-git clone htps://github.com/codeitlikemiley/snipr.git
-cd snipr
-```
-
-### For MacOS
-```sh
-./provision.sh
-```
-
-### For Linux
-```sh
-cargo build --release
-mv ./target/release/snipr /usr/local/bin/snipr
-chmod +x /usr/local/bin/snipr
-```
-
-### For Windows
-```sh
-cargo build --release
-
-# Replace 'YourUsername' with your actual username
-Move-Item .\target\release\snipr.exe C:\Users\YourUsername\bin\snipr.exe
-
-# Again, replace 'YourUsername' with your actual username
-$env:Path += ";C:\Users\YourUsername\bin"
+cargo install snip-cli --bin snip
 ```
 
 ## Managing Multiple Snippets File for Different Languages
 
-You can use the command `snipr config <path>` to change the Snippets File on Runtime.
+You can use the command `snip config <path>` to change the Snippets File on Runtime.
 
 Note: This is quite useful when you want to manage different Snippets File for different languages.
 
@@ -69,20 +37,20 @@ but you can change it by setting the `SNIP_CONFIG_PATH` environment variable.
 1. Help
 
 ```sh
-snipr
+snip
 # or
-snipr --help
+snip --help
 ```
 
 <details>
 <summary>Output</summary>
 
 ```sh
-snipr
+snip
 /Users/uriah/.config/nvim/snippets/rust/rust.json
 A CLI tool for managing Neovim LuaSnip Rust snippets
 
-Usage: snipr <COMMAND>
+Usage: snip <COMMAND>
 
 Commands:
   add         Adds entry to Snippet Collection file
@@ -104,38 +72,38 @@ Options:
 2.  Add new snippet
 ```sh
 # help
-snipr add --help
+snip add --help
 # Add Snippet
-snipr add --key <key> --value <value> --description <description> -- "<snippet>"
+snip add --key <key> --value <value> --description <description> -- "<snippet>"
 ```
 
 3. Remove snippet
 
 ```sh
 # help
-snipr remove --help
+snip remove --help
 # Remove Snippet
-snipr remove --key <key>
+snip remove --key <key>
 ```
 
 4. List all snippets
 
 ```sh
 # help
-snipr ls --help
+snip ls --help
 # Usage
-snipr ls <LIST_OPTION | (key or prefix)>
+snip ls <LIST_OPTION | (key or prefix)>
 # List all Keys
-snipr ls key
+snip ls key
 # List all Prefixes
-snipr ls prefix
+snip ls prefix
 ```
 
 <details>
 <summary>Output</summary>
 
 ```sh
-snipr ls key
+snip ls key
 /Users/uriah/.config/nvim/snippets/rust/rust.json
 [src/main.rs:468] list_option = Key
 impl_iterator
@@ -156,16 +124,16 @@ impl_clone_single_field
 
 ```sh
 # help
-snipr update-key --help
+snip update-key --help
 # Update Key
-snipr update-key  --old-key <old-key> --new-key <new-key>
+snip update-key  --old-key <old-key> --new-key <new-key>
 ```
 
 <details>
 <summary>Output</summary>
 
 ```sh
-snipr update-key --old-key "Fuzz match String" --new-key "fuzzy-match-string"
+snip update-key --old-key "Fuzz match String" --new-key "fuzzy-match-string"
 /Users/uriah/.config/nvim/snippets/rust/rust.json
 [src/main.rs:499] &old_key = "Fuzz match String"
 [src/main.rs:499] &new_key = "fuzzy-match-string"
@@ -177,25 +145,25 @@ snipr update-key --old-key "Fuzz match String" --new-key "fuzzy-match-string"
 
 ```sh
 # help
-snipr edit --help
+snip edit --help
 # Update snippet Value
-snipr edit --key <key> --prefix <prefix> --description <description> -- "<snippet>"
+snip edit --key <key> --prefix <prefix> --description <description> -- "<snippet>"
 ```
 
 7. Search Snippet
 
 ```sh
 # help
-snipr search --help
+snip search --help
 # Search Snippet
-snipr search <ID | (key or prefix)> -- "<search_term>"
+snip search <ID | (key or prefix)> -- "<search_term>"
 ```
 
 <details>
 <summary>Output</summary>
 
 ```sh
-snipr search key -- impl
+snip search key -- impl
 /Users/uriah/.config/nvim/snippets/rust/rust.json
 [src/main.rs:490] id = Some(
     Key,
@@ -216,16 +184,16 @@ impl_partialeq_single_field
 
 ```sh
 # help
-snipr show --help
+snip show --help
 # Show Snippet
-snipr show <key_id>
+snip show <key_id>
 ```
 
 <details>
 <summary>Output</summary>
 
 ```sh
-snipr show impl_deref
+snip show impl_deref
 /Users/uriah/.config/nvim/snippets/rust/rust.json
 [src/main.rs:484] &key = "impl_deref"
 +-------------+-------------------------------------------------------------+
@@ -258,7 +226,7 @@ Note: This can be used to switch Configuration e.g. you wanna manage Python Snip
 
 ```sh
 # help
-snipr config --help
+snip config --help
 # Config Snippet
-snipr config <path>
+snip config <path>
 ```

--- a/provision.sh
+++ b/provision.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 cargo clean
-rm snipr.pkg
+rm snip.pkg
 cargo zigbuild --release
 cargo bundle --release
-pkgbuild --root ./target/release/bundle/osx/snipr.app --install-location "/Applications/snipr.app" --identifier com.codeitlikemiley.snipr --version 0.1.0 --scripts ./scripts snipr.pkg
+pkgbuild --root ./target/release/bundle/osx/snip.app --install-location "/Applications/snip.app" --identifier com.codeitlikemiley.snip --version 0.1.0 --scripts ./scripts snip.pkg

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -17,4 +17,4 @@ if [ -L "$USER_HOME/.local/bin/snip" ]; then
 fi
 
 # Create the symlink in ~/.local/bin
-ln -s "/Applications/snipr.app/Contents/MacOS/snipr" "$USER_HOME/.local/bin/snip"
+ln -s "/Applications/snip.app/Contents/MacOS/snip" "$USER_HOME/.local/bin/snip"

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -17,4 +17,4 @@ if [ -L "$USER_HOME/.local/bin/snip" ]; then
 fi
 
 # Create the symlink in ~/.local/bin
-ln -s "/Applications/snip.app/Contents/MacOS/snip" "$USER_HOME/.local/bin/snip"
+ln -s "/Applications/snip.app/Contents/MacOS/snip-cli" "$USER_HOME/.local/bin/snip"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,19 @@
 use anyhow::{self, Context, Result};
 use clap::Parser;
-use snipr::actions::create_directory_and_file::create_directory_and_file;
-use snipr::actions::edit_snippet_in_file::edit_snippet_in_file;
-use snipr::actions::list_snippets::list_snippets;
-use snipr::actions::remove_snippet_from_file::remove_snippet_from_file;
-use snipr::actions::search_snippets::search_snippets;
-use snipr::actions::show_snippet::show_snippet;
-use snipr::actions::update_key_in_file::update_key_in_file;
-use snipr::actions::write_snippet_to_file::write_snippet_to_file;
-use snipr::constants::DEFAULT_SNIPPET_PATH;
-use snipr::helpers::expand_home_dir::expand_home_dir;
-use snipr::helpers::get_app_config::get_app_config;
-use snipr::models::cli_model::Cli;
-use snipr::models::commands_model::Commands;
-use snipr::models::snip_config_model::SnipConfig;
+use snip_cli::actions::create_directory_and_file::create_directory_and_file;
+use snip_cli::actions::edit_snippet_in_file::edit_snippet_in_file;
+use snip_cli::actions::list_snippets::list_snippets;
+use snip_cli::actions::remove_snippet_from_file::remove_snippet_from_file;
+use snip_cli::actions::search_snippets::search_snippets;
+use snip_cli::actions::show_snippet::show_snippet;
+use snip_cli::actions::update_key_in_file::update_key_in_file;
+use snip_cli::actions::write_snippet_to_file::write_snippet_to_file;
+use snip_cli::constants::DEFAULT_SNIPPET_PATH;
+use snip_cli::helpers::expand_home_dir::expand_home_dir;
+use snip_cli::helpers::get_app_config::get_app_config;
+use snip_cli::models::cli_model::Cli;
+use snip_cli::models::commands_model::Commands;
+use snip_cli::models::snip_config_model::SnipConfig;
 use std::io::Write;
 
 #[tokio::main]


### PR DESCRIPTION
Github Release now output `snip` `bin` or `exe`, that you can download and `Add to your path`.

Cargo Install , default behaviour to install both ws and ws-cli , but can be cherry pick to install with

```sh
cargo install snip-cli --bin ws
```
If you wanna build from source on macOS , the `./provision.sh` would properly create a `snip.app` and linked symlinked from
`snip-cli`to `~/.local/bin/ws`